### PR TITLE
[REFACTOR] Programs: Reorder arguments and inherit usage across modules

### DIFF
--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     (import ./rofi { inherit config pkgs; })
-    (import ./kitty { inherit pkgs unstable config; })
+    (import ./kitty { inherit config pkgs unstable; })
     (import ./zsh { inherit pkgs; })
     (import ./git { inherit pkgs env; })
     (import ./bat { inherit pkgs; })

--- a/modules/programs/kitty/default.nix
+++ b/modules/programs/kitty/default.nix
@@ -1,7 +1,7 @@
-{ pkgs, unstable, config, ...}:
+{ config, pkgs, unstable, ...}:
 
 let
-  nixGL = import ../../nixgl  { inherit pkgs config; };
+  nixGL = import ../../nixgl  { inherit config pkgs; };
 in {
   home.file.".config/kitty/color.ini".source = ./color.ini;
 


### PR DESCRIPTION
## Motivation & Context

- **Why**: To improve code readability and maintain a consistent style across Nix modules.
- **Problem**: Argument and inherit orders were inconsistent, which can lead to confusion and subtle maintenance issues.
- **User impact** or **business value**: No functional change; developer experience is improved through code consistency.

---

## Implementation Details

- **Files Affected**:
  - `modules/programs/default.nix`
  - `modules/programs/kitty/default.nix`
- **Approach**: Reordered function argument lists to follow a standard pattern.
- **Edge Cases**: Ensured that all reordered arguments maintain the same scope and binding; no functional impact introduced.

---

## Testing

- **Manual Steps**:

    ```gherkin
    Feature: Consistent argument ordering in Nix modules

      Background:
        Given the system is running Kali GNU/Linux Rolling 2025.1
        And Nix version is "2.28.0"
        And Home Manager version is "25.05-pre"
        And the Nix environment is defined in "home.nix"
        And the files "programs/default.nix" and "programs/kitty/default.nix" have been updated

      Scenario: Build the Home Manager configuration successfully
        When I run the command
        """
        home-manager switch -f home.nix
        """
        Then it should complete without errors
        And all configured programs must retain their existing functionality
    ```

---

## Acceptance Criteria

- [X] Argument order is consistent across updated files.
- [X] `home-manager switch -f home.nix` applies without error.
- [X] No runtime behavior change introduced.
- [X] Code style is improved and easier to follow.

