### PR TITLE
[REFACTOR] x: Move .xinitrc content into a dedicated file

### DIFF
--- a/modules/x/default.nix
+++ b/modules/x/default.nix
@@ -1,23 +1,10 @@
 { config, pkgs, lib, ... }:
 
 {
-  home.file.".xinitrc".text = ''
-    #!/bin/sh
-    # /etc/X11/xinit/xinitrc
-    
-    # global xinitrc file, used by all X sessions started by xinit (startx)
-    # invoke global X session script
-    . /etc/X11/Xsession
-
-    export DISPLAY=:0
-    export XAUTHORITY="${config.home.homeDirectory}/.Xauthority"
-    /usr/bin/dbus-update-activation-environment --systemd DISPLAY XAUTHORITY
-
-    # VMware
-    if command -v vmware-user-suid-wrapper >/dev/null; then
-      /usr/bin/vmware-user-suid-wrapper &
-    fi
-  '';
+  home.file.".xinitrc".text = builtins.replaceStrings
+    [ "{{homeDirectory}}" ]
+    [ config.home.homeDirectory ]
+    (builtins.readFile ./xinitrc);
 
   xsession = {
     enable = true;

--- a/modules/x/xinitrc
+++ b/modules/x/xinitrc
@@ -1,0 +1,16 @@
+#!/bin/sh
+# /etc/X11/xinit/xinitrc
+
+# global xinitrc file, used by all X sessions started by xinit (startx)
+# invoke global X session script
+. /etc/X11/Xsession
+
+export DISPLAY=:0
+export XAUTHORITY="{{homeDirectory}}/.Xauthority"
+/usr/bin/dbus-update-activation-environment --systemd DISPLAY XAUTHORITY
+
+# VMware
+if command -v vmware-user-suid-wrapper >/dev/null; then
+  /usr/bin/vmware-user-suid-wrapper &
+fi
+


### PR DESCRIPTION
## Motivation & Context

- **Why:** To improve maintainability, readability, and consistency of the `.xinitrc` configuration within the Nix module system.
- **Problem:** The `.xinitrc` file content was previously defined inline as a string in `modules/x/default.nix`. This made it difficult to manage, edit, and track changes to the file over time.
- **User impact or business value:** No functional change to the user experience; however, future maintenance is simplified and editing the `.xinitrc` file is now straightforward.

---

## Implementation Details

- **Files Affected:**
  - `modules/x/default.nix`
  - `modules/x/xinitrc` (new)
- **Approach:**
  - Moved the embedded `.xinitrc` shell script content from an inline string in `default.nix` to an external file (`xinitrc`).
  - Used `builtins.readFile` with `builtins.replaceStrings` to allow dynamic injection of `config.home.homeDirectory` into the external file using a `{{homeDirectory}}` placeholder.
- **Edge Cases:**
  - No behavioral or runtime changes.
  - Care was taken to preserve all existing environment setup steps and comments. The new file retains all logic from the original inline version.

---

## Testing

- **Manual Steps:**

    ```gherkin
    Feature: Load `.xinitrc` content from an external file with dynamic home directory injection

      Background:
        Given the system is running Kali GNU/Linux Rolling 2025.1
        And Nix version is "2.28.0"
        And Home Manager version is "25.05-pre"
        And the Nix environment is defined in "home.nix"
        And the file "modules/x/default.nix" has been updated
        And the file "modules/x/xinitrc" has been created

      Scenario: Build the Home Manager configuration successfully
        When I run the command
        """
        home-manager switch -f home.nix
        """
        Then it should complete without errors
        And the .xinitrc file must be correctly generated in the user’s home directory
        And the content must match the expected environment setup
        And all configured programs must retain their existing functionality
    ```

---

## Acceptance Criteria

- [X] `.xinitrc` is now stored in a separate file (`modules/x/xinitrc`).
- [X] `home-manager switch -f home.nix` builds and applies without errors.
- [X] The generated `.xinitrc` behaves identically to the previous inline version.
- [X] Code is cleaner, easier to maintain, and future edits to `.xinitrc` are straightforward.
