### PR TITLE
[Fix] i3: Fix open navigator in workspace

### DIFF
--- a/modules/x/i3/default.nix
+++ b/modules/x/i3/default.nix
@@ -257,7 +257,10 @@ in {
       defaultWorkspace = "workspace number 1";
       # Allocate applications to workspaces
       assigns = {
-        "2" = [{ class = "LibreWolf"; }];
+        "2" = [
+          { class = "Navigator"; }
+          { class = "librewolf"; }
+        ];
         "3" = [
           { class = "burp-StartBurp"; }
           { class = "org-zaproxy-zap-ZAP"; }


### PR DESCRIPTION
## Motivation & Context

**Why:**  
To ensure the i3 window manager correctly opens the web browser in workspace 2, improving user workflow consistency.

**Problem:**  
The window assignment for workspace 2 previously used only `LibreWolf` as the class. However, since it was not included in the assignment did not work.

**User impact or business value:**  
Fixes unexpected behavior where the browser window might open in the wrong workspace or not be properly managed. Ensures all variants of the browser class open consistently in workspace 2.

---

## Implementation Details

**Files Affected:**

- `modules/x/i3/default.nix`

**Approach:**

- Expanded the assignment list for workspace `"2"` to include additional `class` values: `"Navigator"` and `"librewolf"`.
- Replaced the single string mapping with a list to allow for multiple window class matches.

**Edge Cases:**

- Care was taken to preserve compatibility with the existing configuration format.
- No changes to behavior for other workspaces or applications.

---

## Testing

### Manual Steps

**Feature:** i3 workspace assigns all browser window classes to workspace 2

#### Background

- Given the system is running **Kali GNU/Linux Rolling 2025.1**  
- And **Nix** version is `"2.28.0"`  
- And **Home Manager** version is `"25.05-pre"`  
- And the file `modules/x/i3/default.nix` has been updated  

#### Scenario: Assign browser windows correctly to workspace 2

```gherkin
Feature: Assign browser windows to workspace 2 in i3

  Background:
    Given the system is running Kali GNU/Linux Rolling 2025.1
    And Nix version is "2.28.0"
    And Home Manager version is "25.05-pre"
    And the Nix environment is defined in "home.nix"
    And the file "modules/x/i3/default.nix" has been updated

  Scenario: Build and apply the Home Manager configuration with updated window class assignments
    When I run the command
    """
    home-manager switch -f home.nix
    """
    Then it should complete without errors
    And when I open a window with class "Navigator", or "librewolf"
    Then it must be placed in workspace number 2
    And all other configured programs must retain their existing workspace behavior
```

---

## Acceptance Criteria

- [X] i3 configuration correctly assigns Navigator, and librewolf class windows to workspace 2.
- [X] No regressions or changes to other workspace mappings.
- [X] `home-manager switch -f home.nix` builds and applies without errors.
- [X] The window manager behaves as expected when opening the browser.