### PR TITLE
[Feat] NeoVim: Add copilot plugin

### DIFF
--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -8,6 +8,6 @@
     (import ./git { inherit pkgs env; })
     (import ./bat { inherit pkgs; })
     (import ./jq { inherit pkgs; })
-    (import ./neovim { inherit pkgs; })
+    (import ./neovim { inherit pkgs unstable; })
   ];
 }

--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, unstable, ... }:
 
 {
   programs.neovim = {
@@ -6,32 +6,36 @@
     defaultEditor = true;
     vimAlias = true;
     plugins = let
-      nvim-treesitter-with-plugins = pkgs.vimPlugins.nvim-treesitter.withPlugins (treesitter-plugins:
-        with treesitter-plugins; [
-          bash
-          c
-          lua
-          markdown
-          markdown_inline
-          nix
-          python
-          vim
-          vimdoc
-        ]);
+      nvim-treesitter-with-plugins =
+        pkgs.vimPlugins.nvim-treesitter.withPlugins (treesitter-plugins:
+          with treesitter-plugins; [
+            bash
+            c
+            lua
+            markdown
+            markdown_inline
+            nix
+            python
+            vim
+            vimdoc
+          ]);
     in
-      with pkgs.vimPlugins; [
-        csv-vim
-        edge
-        indent-blankline-nvim
-        jedi-vim
-        nvim-cmp
-        nvim-treesitter-with-plugins
-        todo-comments-nvim
-        vim-airline
-        vim-airline-themes
-        vim-nix
-        vim-autoformat
-      ];
+      [
+        unstable.vimPlugins.copilot-vim
+      ] ++ (with pkgs.vimPlugins; [
+      csv-vim
+      edge
+      indent-blankline-nvim
+      jedi-vim
+      nvim-cmp
+      nvim-treesitter-with-plugins
+      todo-comments-nvim
+      vim-airline
+      vim-airline-themes
+      vim-nix
+      vim-autoformat
+    ]);
     extraLuaConfig = builtins.readFile ./init.lua;
   };
 }
+


### PR DESCRIPTION
## Motivation & Context

**Why:**
To enable Neovim to use plugins from the unstable package set, allowing integration of newer or experimental plugins like GitHub Copilot.

**Problem:**
Neovim plugin management was limited to the stable package set, preventing use of some advanced plugins such as copilot-vim.

**User impact or business value:**
User gain access to GitHub Copilot and other unstable plugins inside Neovim, improving coding assistance and productivity.

---

## Implementation Details

**Files Affected:**

- `modules/programs/default.nix`
- `modules/programs/neovim/default.nix`

**Approach:**

- Modified the Neovim module to accept the unstable package set as an argument.
- Updated plugin list logic in neovim/default.nix to combine plugins from unstable.vimPlugins and the stable pkgs.vimPlugins.
- Added copilot-vim plugin from unstable.vimPlugins to the plugin list.
- Updated modules/programs/default.nix to pass the unstable package set to the Neovim module.

**Edge Cases:**

- Stable plugins remain functional without changes.
- No breaking changes introduced for other configurations.

---

## Testing

### Manual Steps

**Feature:** Neovim supports plugins from the unstable package set including Copilot

#### Background:

- Given the system uses Nix with both stable and unstable channels
- And the Neovim module is updated to receive unstable
- And the Copilot plugin is included in the plugin list

#### Scenario: Build and apply the updated Nix configuration
When I run

```gherkin
Feature: Assign browser windows to workspace 2 in i3

  Background:
    Given the system is running Kali GNU/Linux Rolling 2025.1
    And Nix version is "2.28.0"
    And Home Manager version is "25.05-pre"
    And the Nix environment is defined in "home.nix"
    And the file "modules/programs/default.nix" has been updated
    And the file "modules/programs/neovim/default.nix" has been updated

  Scenario: Build and apply the Home Manager configuration with copilot neovim plugin installed
    When I run the command
    """
    home-manager switch -f home.nix
    """
    Then it should complete without errors
    And when I open a neovim
    And I run the command
    """
    :Copilot status
    """
    Then it must display "Copilot: Ready"
    And all other configured plugins must retain their existing working status
```

---

## Acceptance Criteria

- [X] Neovim loads plugins from both stable and unstable sets.
- [X] GitHub Copilot plugin is installed and functional.
- [X] No regressions or errors in Neovim configuration.
- [X] Build and configuration apply without issues.